### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -11,6 +11,9 @@ on:
       - .go-version
       - docs/**
 
+permissions:
+  contents: read
+
 jobs:
   markdown-link-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,10 @@ name: Go Linter
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
 jobs:
   golangci:
     name: Run linter

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,10 @@ name: Test suite
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Run tests

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/mbarper/terraform-provider-pingdom
 go 1.19
 
 require (
-	github.com/mbarper/go-pingdom v1.4.3
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.24.1
+	github.com/mbarper/go-pingdom v1.4.3
 	github.com/mitchellh/mapstructure v1.5.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,6 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/mbarper/go-pingdom v1.4.0 h1:S4ZvuVcKAqNQkXRMlO6dyaqhLTPKAECblp5g2mw8n/0=
-github.com/mbarper/go-pingdom v1.4.0/go.mod h1:RN3TNqToiG8ECbjymFJKrw6NCpePVknycuvVlt63JnU=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/Microsoft/go-winio v0.4.16 h1:FtSW/jqD+l4ba5iPBj9CODVtgfYAD8w2wS923g/cFDk=
 github.com/Microsoft/go-winio v0.4.16/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugXOPRXwdLnMv0=
@@ -138,6 +136,8 @@ github.com/mattn/go-colorable v0.1.12/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-isatty v0.0.14 h1:yVuAays6BHfxijgZPzw+3Zlu5yQgKGP2/hcQbHb7S9Y=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
+github.com/mbarper/go-pingdom v1.4.3 h1:PJLALv+fUUu/aqByJ8ats1jCo2TiIOkH3hc+69P7OSg=
+github.com/mbarper/go-pingdom v1.4.3/go.mod h1:EQEvHLBpAb3fLoL9N+mnZqPam/ph1OWxSE/C6fyZQRw=
 github.com/mitchellh/copystructure v1.2.0 h1:vpKXTN4ewci03Vljg/q9QvCGUDttBOGBIa15WveJJGw=
 github.com/mitchellh/copystructure v1.2.0/go.mod h1:qLl+cE2AmVv+CoeAwDPye/v+N2HKCj9FbZEVFJRxO9s=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=


### PR DESCRIPTION
Potential fix for [https://github.com/contentful/terraform-provider-pingdom/security/code-scanning/4](https://github.com/contentful/terraform-provider-pingdom/security/code-scanning/4)

To fix the problem, explicitly define a `permissions` block that limits the `GITHUB_TOKEN` to the least privileges required. These jobs only need to read repository contents for checking markdown files, so `contents: read` is sufficient.

The best fix with minimal impact is to add a workflow-level `permissions` section near the top of `.github/workflows/documentation.yml`, so it applies to all jobs unless they override it. Specifically, insert:

```yaml
permissions:
  contents: read
```

after the `on:` block (e.g., after line 12 or line 13). No changes to the jobs themselves, steps, or actions are necessary. No imports or additional methods are involved because this is a YAML configuration change within the GitHub Actions workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
